### PR TITLE
Include projectDir in the APK path samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ composer {
 
   configs { 
     redDebug {
-      apk 'app/build/outputs/apk/example-debug.apk' //optional override
-      testApk 'build/outputs/apk/example-debug-androidTest.apk' //optional override
+      apk "${projectDir}/build/outputs/apk/debug/example-debug.apk" //optional override
+      testApk "${projectDir}/build/outputs/apk/androidTest/debug/example-debug-androidTest.apk" //optional override
       shard true //optional. default true
       outputDirectory 'artifacts/composer-output' //optional override. default 'build/reports/composer/redDebug'
       instrumentationArgument('key1', 'value1') //optional
@@ -62,8 +62,8 @@ composer {
 Manual task creation looks something like this:
 ```groovy
 task customTaskName(type: ComposerTask) {
-  apk 'app/build/outputs/apk/example-debug.apk' //required
-  testApk 'build/outputs/apk/example-debug-androidTest.apk' //required
+  apk "${projectDir}/build/outputs/apk/example-debug.apk" //required
+  testApk "${projectDir}/build/outputs/apk/example-debug-androidTest.apk" //required
   shard true //optional
   outputDirectory 'artifacts/composer-output' //optional
   instrumentationArgument('key1', 'value1') //optional

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ composer {
 
   configs { 
     redDebug {
-      apk "${projectDir}/build/outputs/apk/debug/example-debug.apk" //optional override
-      testApk "${projectDir}/build/outputs/apk/androidTest/debug/example-debug-androidTest.apk" //optional override
+      apk "build/outputs/apk/debug/example-debug.apk" //optional override, string paths are evaluated as per {@link org.gradle.api.Project#file(Object)}.
+      testApk = new File(buildDir, "outputs/apk/androidTest/debug/example-debug-androidTest.apk") //optional override
       shard true //optional. default true
       outputDirectory 'artifacts/composer-output' //optional override. default 'build/reports/composer/redDebug'
       instrumentationArgument('key1', 'value1') //optional
@@ -62,8 +62,8 @@ composer {
 Manual task creation looks something like this:
 ```groovy
 task customTaskName(type: ComposerTask) {
-  apk "${projectDir}/build/outputs/apk/example-debug.apk" //required
-  testApk "${projectDir}/build/outputs/apk/example-debug-androidTest.apk" //required
+  apk "build/outputs/apk/example-debug.apk" //required
+  testApk "build/outputs/apk/example-debug-androidTest.apk" //required
   shard true //optional
   outputDirectory 'artifacts/composer-output' //optional
   instrumentationArgument('key1', 'value1') //optional
@@ -124,7 +124,7 @@ The `composer` configuration is automatically added to your project once a
 
 ```groovy
 dependencies {
- composer "com.gojuno.composer:composer:0.3.2"
+ composer "com.gojuno.composer:composer:0.3.3"
 }
 ```
 
@@ -136,7 +136,7 @@ version of gradle is 4.0 or whatever minimum is mandated by the android gradle p
 
 Composer plugin version | Gradle version | Android plugin version
 ----- | ---- | -----
-0.6.0 | 4.6  | 3.1.0
+0.6.0 | 4.10  | 3.1.4
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.2.61'
 
     repositories {
         jcenter()

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerConfigurator.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerConfigurator.kt
@@ -20,29 +20,60 @@ import java.io.File
 
 interface ComposerConfigurator {
     var apk: File?
+
     var testApk: File?
+
     var shard: Boolean?
+
     var outputDirectory: File
+
     val instrumentationArguments: MutableList<Pair<String, String>>
+
     var verboseOutput: Boolean?
+
     var devices: MutableList<String>
+
     var devicePattern: String?
+
     var keepOutput: Boolean?
+
     var apkInstallTimeout: Int?
 
     fun apk(value: File)
+
+    /**
+     * Paths are evaluated as per {@link org.gradle.api.Project#file(Object)}.
+     */
     fun apk(value: String)
+
     fun testApk(value: File)
+    /**
+     * Paths are evaluated as per {@link org.gradle.api.Project#file(Object)}.
+     */
     fun testApk(value: String)
+
     fun shard(value: Boolean)
+
     fun outputDirectory(value: File)
+
+    /**
+     * Paths are evaluated as per {@link org.gradle.api.Project#file(Object)}.
+     */
     fun outputDirectory(value: String)
+
     fun instrumentationArgument(key: String, value: String)
+
     fun instrumentationArguments(vararg values: Pair<String, String>)
+
     fun verboseOutput(value: Boolean)
+
     fun device(value: String)
+
     fun devices(vararg values: String)
+
     fun devicePattern(value: String)
+
     fun keepOutput(value: Boolean)
+
     fun apkInstallTimeout(value: Int)
 }

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
@@ -30,8 +30,8 @@ open class ComposerTask : JavaExec(), ComposerConfigurator {
     companion object {
         private const val MAIN_CLASS = "com.gojuno.composer.MainKt"
         private const val COMPOSER = "composer"
-        private const val ARTIFACT_DEP = "com.gojuno.composer:composer:0.3.2"
-        val DEFAULT_OUTPUT_DIR = File("composer-output")
+        private const val ARTIFACT_DEP = "com.gojuno.composer:composer:0.3.3"
+        const val DEFAULT_OUTPUT_DIR = "composer-output"
 
         fun createComposerConfiguration(project: Project) {
             if (project.configurations.findByName(COMPOSER) == null) {
@@ -39,10 +39,6 @@ open class ComposerTask : JavaExec(), ComposerConfigurator {
                 project.dependencies.add(COMPOSER, ARTIFACT_DEP)
             }
         }
-    }
-
-    init {
-        createComposerConfiguration(project)
     }
 
     @InputFile
@@ -55,7 +51,7 @@ open class ComposerTask : JavaExec(), ComposerConfigurator {
     override var shard: Boolean? = null
 
     @get:[Input OutputDirectory]
-    override var outputDirectory: File = DEFAULT_OUTPUT_DIR
+    override lateinit var outputDirectory: File
 
     @Input
     override val instrumentationArguments = mutableListOf<Pair<String, String>>()
@@ -80,6 +76,12 @@ open class ComposerTask : JavaExec(), ComposerConfigurator {
 
     @get:[Input Optional]
     override var apkInstallTimeout: Int? = null
+
+    init {
+        createComposerConfiguration(project)
+        @Suppress("LeakingThis")
+        outputDirectory = project.file(DEFAULT_OUTPUT_DIR)
+    }
 
     override fun exec() {
         if (outputDirectory.exists()) {
@@ -109,7 +111,7 @@ open class ComposerTask : JavaExec(), ComposerConfigurator {
     }
 
     override fun apk(value: String) {
-        apk(File(value))
+        apk(project.file(value))
     }
 
     override fun testApk(value: File) {
@@ -117,7 +119,7 @@ open class ComposerTask : JavaExec(), ComposerConfigurator {
     }
 
     override fun testApk(value: String) {
-        testApk(File(value))
+        testApk(project.file(value))
     }
 
     override fun shard(value: Boolean) {
@@ -129,7 +131,7 @@ open class ComposerTask : JavaExec(), ComposerConfigurator {
     }
 
     override fun outputDirectory(value: String) {
-        outputDirectory(File(value))
+        outputDirectory(project.file(value))
     }
 
     override fun instrumentationArguments(vararg values: Pair<String, String>) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -17,7 +17,7 @@ gradlePlugin {
 
 dependencies {
     compile project(':core')
-    compile group: 'com.android.tools.build', name: 'gradle', version: '3.1.0'
+    compile group: 'com.android.tools.build', name: 'gradle', version: '3.1.4'
 }
 
 dependencies {

--- a/plugin/src/main/kotlin/com/trevjonez/composer/ComposerPlugin.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ComposerPlugin.kt
@@ -21,7 +21,7 @@ import com.android.build.gradle.api.ApplicationVariant
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
 import java.io.File
 import kotlin.reflect.KClass
 
@@ -40,7 +40,7 @@ class ComposerPlugin : Plugin<Project> {
     }
 
     private fun observeVariants(project: Project) {
-        val androidExtension = project.extensions.getByName("android")
+        val androidExtension = project.extensions.findByName("android")
 
         @Suppress("FoldInitializerAndIfToElvis")
         if (androidExtension == null)
@@ -51,53 +51,52 @@ class ComposerPlugin : Plugin<Project> {
             throw IllegalStateException("composer plugin only applicable to android application projects, open an issue if you need something else.")
         }
 
-        androidExtension.applicationVariants.all {
-            if (config.variants.isEmpty() || config.variants.contains(it.name)) {
-                if (it.testVariant == null) return@all
+        androidExtension.applicationVariants.all { variant ->
+            if (config.variants.isEmpty() || config.variants.contains(variant.name)) {
+                if (variant.testVariant == null) return@all
+                val assembleTask = project.tasks.named("assemble${variant.name.capitalize()}")
+                                   ?: throw IllegalStateException("Couldn't find registered assemble task for variant ${variant.name}")
 
-                val assembleTask: Task = project.tasks.findByName("assemble${it.name.capitalize()}")
-                                         ?: throw IllegalStateException("Couldn't find assemble task for variant ${it.name}")
+                val assembleTestTask = project.tasks.named("assemble${variant.name.capitalize()}AndroidTest")
+                                             ?: throw IllegalStateException("Couldn't find registered assemble android test task for variant ${variant.name}")
 
-                val assembleTestTask: Task = project.tasks.findByName("assemble${it.name.capitalize()}AndroidTest")
-                                             ?: throw IllegalStateException("Couldn't find assemble android test task for variant ${it.name}")
-
-                val configurator: ConfiguratorDomainObj? = config.configs.findByName(it.name)
-                project.createTask(
+                val configurator: ConfiguratorDomainObj? = config.configs.findByName(variant.name)
+                project.registerTask(
                         type = ComposerTask::class,
-                        name = "test${it.name.capitalize()}Composer",
-                        description = "Run composer for ${it.name} variant",
+                        name = "test${variant.name.capitalize()}Composer",
+                        description = "Run composer for ${variant.name} variant",
                         dependsOn = listOf(assembleTask, assembleTestTask))
-                        .apply {
-                            apk = getApk(it, configurator)
-                            testApk = getTestApk(it, configurator)
-                            shard = configurator?.shard
-                            outputDirectory = getOutputDirectory(it, configurator, project)
-                            instrumentationArguments.addAll(collectInstrumentationArgs(configurator))
-                            verboseOutput = configurator?.verboseOutput
-                            configurator?.configureTask?.execute(this)
-                            environment("ANDROID_HOME", androidExtension.sdkDirectory.absolutePath)
-                            devices = configurator?.devices ?: mutableListOf()
-                            devicePattern = configurator?.devicePattern
-                            keepOutput = configurator?.keepOutput
-                            apkInstallTimeout = configurator?.apkInstallTimeout
+                        .configure { task ->
+                            task.apply {
+                                apk = getApk(variant, configurator)
+                                testApk = getTestApk(variant, configurator)
+                                shard = configurator?.shard
+                                outputDirectory = getOutputDirectory(variant, configurator, project)
+                                instrumentationArguments.addAll(collectInstrumentationArgs(configurator))
+                                verboseOutput = configurator?.verboseOutput
+                                configurator?.configureTask?.execute(this)
+                                environment("ANDROID_HOME", androidExtension.sdkDirectory.absolutePath)
+                                devices = configurator?.devices ?: mutableListOf()
+                                devicePattern = configurator?.devicePattern
+                                keepOutput = configurator?.keepOutput
+                                apkInstallTimeout = configurator?.apkInstallTimeout
+                            }
                         }
             }
         }
     }
 
-    private fun <T : DefaultTask> Project.createTask(type: KClass<T>,
-                                                     name: String,
-                                                     group: String = GROUP,
-                                                     description: String? = null,
-                                                     dependsOn: List<Task>? = null)
-            : T {
-        return type.java.cast(project.tasks.create(LinkedHashMap<String, Any>().apply {
-            put("name", name)
-            put("type", type.java)
-            put("group", group)
-            description?.let { put("description", it) }
-            dependsOn?.let { put("dependsOn", it) }
-        }))
+    private fun <T : DefaultTask> Project.registerTask(type: KClass<T>,
+                                                       name: String,
+                                                       group: String = GROUP,
+                                                       description: String? = null,
+                                                       dependsOn: List<Any>? = null)
+            : TaskProvider<T> {
+        return project.tasks.register(name, type.java) { task ->
+            task.group = group
+            description?.let { task.description = it }
+            dependsOn?.let { task.dependsOn(*it.toTypedArray()) }
+        }
     }
 
     private fun collectInstrumentationArgs(configurator: ComposerConfigurator?): List<Pair<String, String>> {
@@ -143,12 +142,10 @@ class ComposerPlugin : Plugin<Project> {
     }
 
     private fun getOutputDirectory(variant: ApplicationVariant, configurator: ConfiguratorDomainObj?, project: Project): File {
-        return if (configurator == null || configurator.outputDirectory == ComposerTask.DEFAULT_OUTPUT_DIR) {
+        return if (configurator == null || configurator.outputDirectory == project.file(ComposerTask.DEFAULT_OUTPUT_DIR)) {
             File(project.buildDir, "reports/composer/${variant.name}")
         } else {
             configurator.outputDirectory
         }
     }
-
-    private fun ApplicationVariant.testPackage(): String = "$applicationId.test"
 }

--- a/plugin/src/main/kotlin/com/trevjonez/composer/ConfigExtension.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ConfigExtension.kt
@@ -22,7 +22,9 @@ import org.gradle.api.Project
 
 open class ConfigExtension(project: Project) {
     val configs: NamedDomainObjectContainer<ConfiguratorDomainObj> =
-            project.container(ConfiguratorDomainObj::class.java)
+            project.container(ConfiguratorDomainObj::class.java) { name ->
+                ConfiguratorDomainObj(name, project)
+            }
 
     val variants = mutableListOf<String>()
 

--- a/plugin/src/main/kotlin/com/trevjonez/composer/ConfiguratorDomainObj.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ConfiguratorDomainObj.kt
@@ -17,14 +17,15 @@
 package com.trevjonez.composer
 
 import org.gradle.api.Action
+import org.gradle.api.Project
 import java.io.File
 import kotlin.properties.Delegates
 
-open class ConfiguratorDomainObj(val name: String) : ComposerConfigurator {
+open class ConfiguratorDomainObj(val name: String, project: Project) : ComposerConfigurator {
     override var apk: File? = null
     override var testApk: File? = null
     override var shard: Boolean? = null
-    override var outputDirectory: File = ComposerTask.DEFAULT_OUTPUT_DIR
+    override var outputDirectory: File = project.file(ComposerTask.DEFAULT_OUTPUT_DIR)
     override val instrumentationArguments: MutableList<Pair<String, String>> = mutableListOf()
     override var verboseOutput: Boolean? = null
     override var devices: MutableList<String> by Delegates.observable(mutableListOf()) { _, _, newValue ->

--- a/plugin/src/test/kotlin/com/trevjonez/composer/ComposerPluginTest.kt
+++ b/plugin/src/test/kotlin/com/trevjonez/composer/ComposerPluginTest.kt
@@ -27,7 +27,6 @@ import java.io.File
 class ComposerPluginTest {
     @Rule @JvmField val testProjectDir = TemporaryFolder()
 
-
     /**
      * Run with an emulator connected on port 5554
      */
@@ -57,7 +56,7 @@ class ComposerPluginTest {
     }
 
     /**
-     * Run with an emulator connected on port 5554
+     * Run with at least one device/emulator connected
      */
     @Test
     fun customTaskFindsApk() {

--- a/plugin/src/test/kotlin/com/trevjonez/composer/ComposerPluginTest.kt
+++ b/plugin/src/test/kotlin/com/trevjonez/composer/ComposerPluginTest.kt
@@ -55,4 +55,32 @@ class ComposerPluginTest {
                                                       "Test run finished, 0 passed, 0 failed",
                                                       "Error: 0 tests were run.")
     }
+
+    /**
+     * Run with an emulator connected on port 5554
+     */
+    @Test
+    fun customTaskFindsApk() {
+        val projectDir = testProjectDir.newFolder("vanilla").also {
+            FileUtils.copyDirectory(File(javaClass.classLoader.getResource("vanilla").path), it)
+            File(it, "local.properties").writeText("sdk.dir=${System.getenv("HOME")}/Library/Android/sdk", Charsets.UTF_8)
+            File(it, "libs").also {
+                it.mkdir()
+                FileUtils.copyFileToDirectory(File(".", "build/libs/plugin.jar"), it)
+                FileUtils.copyFileToDirectory(File(".", "../core/build/libs/core.jar"), it)
+            }
+        }
+
+        val result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments("customTask", "--info")
+                .withDebug(true)
+                .forwardOutput()
+                .buildAndFail()
+
+        assertThat(result.output).contains("Successfully installed apk",
+                                                      "Starting tests",
+                                                      "Test run finished, 0 passed, 0 failed",
+                                                      "Error: 0 tests were run.")
+    }
 }

--- a/plugin/src/test/resources/vanilla/build.gradle
+++ b/plugin/src/test/resources/vanilla/build.gradle
@@ -72,3 +72,8 @@ composer {
     }
 }
 
+import com.trevjonez.composer.ComposerTask
+task customTask(type: ComposerTask, dependsOn: ['assembleDebug', 'assembleDebugAndroidTest']) {
+    apk "${project.projectDir}/build/outputs/apk/debug/vanilla-debug.apk"
+    testApk "${project.projectDir}/build/outputs/apk/androidTest/debug/vanilla-debug-androidTest.apk"
+}


### PR DESCRIPTION
Hi! 
I was trying to create a custom task to run a subset of test, and I just spent a couple of hours trying to figure out why the plugin wasn't finding the APKs. So I decided to open this PR in case you think it would be useful for other people in the future. Also added a new test case, which I used to debug the issue.

### Short version:
When the `File` objects pointing to the APKs are created, they're relativ. Because of that Composer would not find them. No matter how I wrote them, either the plugin could not find it, or it could but then the Composer command would not. Weird. Although running the task from AndroidStudio would work. Even weirder. In the end I found out that adding `${projectDir}` as prefix to the path would make it work in all cases. ¯\\\_(ツ)\_/¯

### Very long version
Turns out the `File` object pointing to the APK created in both `ConfiguratorDomainObj` and `ComposerTask` with 
```
override fun apk(value: String) {
    apk(File(value))
}
```
creates a relative path. 

Because of this, I saw that execution would be inconsistent depending on how you write the path and where you ran the task from. 

For example in the test I added, when using `apk "build/outputs/...` the plugin would find the apk but then Composer would use a wrong path like `/Users/rafael.vazquez/Android/composer-gradle-plugin/plugin/build/outputs/...` and fail. (Should be using the temporary folder like `/private/var/folders/r9/lhsyb_795qgdv0524gdyfyyw0000gp/T/junit8993139078181683454/vanilla/vanilla/build/outputs/...`.

So, I tried to make the file path absolute. It can be done inside `ComposerTask` without any problem with
```
override fun apk(value: String) {
    apk(File(project.projectDir, value))
}
```

But I didn't find a way to do the same in `ConfiguratorDomainObj` because this object doesn't have direct access to the `project` instance. Maybe there is a way but I could not find one 😢 

So I went for the fast and cheap solution, just use the full path in the gradle configuration 😂 

I hope this is useful!
Feel free to reject any or all of the changes if you don't think it's the best approach.

And thanks for the plugin, the neat code and those lovely integration tests (they helped me a lot to find the issue) 😃 