### PR TITLE
Support withOrchestrator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ composer {
   devices(['emulator-5558', 'emulator-5559'])
       
   //These dsl functions are overwritten by variant specific config if any exists
-  shard false 
+  withOrchestrator true
+  shard false
   verboseOutput false
   keepOutput true
   devicePattern 'somePattern'
@@ -55,6 +56,7 @@ composer {
       apk "build/outputs/apk/debug/example-debug.apk" //optional override, string paths are evaluated as per {@link org.gradle.api.Project#file(Object)}.
       testApk = new File(buildDir, "outputs/apk/androidTest/debug/example-debug-androidTest.apk") //optional override
       outputDirectory 'artifacts/composer-output' //optional override. default 'build/reports/composer/redDebug'
+      withOrchestrator false // optional, default false
       shard true //optional. default true
       instrumentationArgument('key1', 'value1') //optional, additive
       instrumentationArgument('key2', 'value2')
@@ -78,6 +80,7 @@ Manual task creation looks something like this:
 task customTaskName(type: ComposerTask) {
   apk "build/outputs/apk/example-debug.apk" //required
   testApk "build/outputs/apk/example-debug-androidTest.apk" //required
+  withOrchestrator true // optional
   shard true //optional
   outputDirectory 'artifacts/composer-output' //optional
   instrumentationArgument('key1', 'value1') //optional

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerConfig.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerConfig.kt
@@ -24,7 +24,7 @@ import org.gradle.api.artifacts.Configuration
 object ComposerConfig {
     const val MAIN_CLASS = "com.gojuno.composer.MainKt"
     const val COMPOSER = "composer"
-    const val COMPOSER_VER = "0.3.3"
+    const val COMPOSER_VER = "0.4.0"
     const val ARTIFACT_DEP = "com.gojuno.composer:composer:$COMPOSER_VER"
     const val DEFAULT_OUTPUT_DIR = "composer-output"
 }

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerConfigurator.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerConfigurator.kt
@@ -17,17 +17,13 @@
 package com.trevjonez.composer
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
-import java.util.concurrent.Callable
 
 interface ComposerConfigurator: ComposerDsl {
     val configuration: Configuration
 
+    val withOrchestrator: Property<Boolean>
     val shard: Property<Boolean>
     val instrumentationArguments: ListProperty<Pair<String, String>>
     val verboseOutput: Property<Boolean>

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerDsl.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerDsl.kt
@@ -24,6 +24,13 @@ import org.gradle.api.file.RegularFileProperty
  */
 interface ComposerDsl {
   /**
+   * Default false
+   *
+   * @param value evaluated as per [org.gradle.api.provider.Property.set].
+   */
+  fun withOrchestrator(value: Any)
+
+  /**
    * Defaults to true
    *
    * @param value evaluated as per [org.gradle.api.provider.Property.set].

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
@@ -21,6 +21,7 @@ import java.io.File
 data class ComposerParams(
         val apk: File,
         val testApk: File,
+        val withOrchestrator: Boolean?,
         val shard: Boolean?,
         val outputDirectory: File?,
         val instrumentationArguments: List<Pair<String, String>>,
@@ -41,6 +42,11 @@ data class ComposerParams(
         return listOf(
                 "--apk", apk.absolutePath,
                 "--test-apk", testApk.absolutePath)
+                .let { params ->
+                  withOrchestrator?.takeIf { it }?.let {
+                    params + arrayOf("--with-orchestrator")
+                  } ?: params
+                }
                 .let { params ->
                     shard?.let {
                         params + arrayOf("--shard", "$it")

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
@@ -24,7 +24,6 @@ import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.kotlin.dsl.listProperty
-import org.gradle.kotlin.dsl.property
 import java.io.File
 
 //TODO: use the worker api not JavaExec
@@ -43,6 +42,9 @@ open class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
   override val outputDir = this.newOutputDirectory().apply {
     set(project.file(ComposerConfig.DEFAULT_OUTPUT_DIR))
   }
+
+  @get:[Optional Input]
+  override val withOrchestrator = project.emptyProperty<Boolean>()
 
   @get:[Optional Input]
   override val shard = project.emptyProperty<Boolean>()
@@ -78,6 +80,7 @@ open class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
     val config = ComposerParams(
         apk.asFile.get(),
         testApk.asFile.get(),
+        withOrchestrator.orNull,
         shard.orNull,
         outputDir,
         instrumentationArguments.orEmpty,
@@ -118,6 +121,10 @@ open class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
 
   override fun outputDirectory(path: Any) {
     outputDir.set(project.file(path))
+  }
+
+  override fun withOrchestrator(value: Any) {
+    withOrchestrator.eval(value)
   }
 
   override fun shard(value: Any) {

--- a/core/src/test/kotlin/com/trevjonez/composer/ComposerTaskTest.kt
+++ b/core/src/test/kotlin/com/trevjonez/composer/ComposerTaskTest.kt
@@ -200,6 +200,19 @@ class ComposerTaskTest {
   }
 
   @Test
+  fun `Task DSL withOrchestrator`() {
+    //language=Groovy
+    makeBuildFile(taskDsl = """
+      $defaultTaskDsl
+      withOrchestrator(true)
+    """.trimIndent()).writeTo(buildFile)
+
+    val runResult = buildRunner().buildAndFail()
+
+    assertThat(runResult.output).contains(dumpFailedError)
+  }
+
+  @Test
   fun `Task DSL instArg`() {
     //language=Groovy
     makeBuildFile(taskDsl = """

--- a/plugin/src/main/kotlin/com/trevjonez/composer/ConfigExtension.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ConfigExtension.kt
@@ -47,6 +47,8 @@ open class ConfigExtension(project: Project)
 
   override val configuration: Configuration = project.composerConfig()
 
+  override val withOrchestrator = project.emptyProperty<Boolean>()
+
   override val shard = project.emptyProperty<Boolean>()
 
   override val instrumentationArguments =
@@ -57,6 +59,10 @@ open class ConfigExtension(project: Project)
   override val devicePattern = project.emptyProperty<String>()
   override val keepOutput = project.emptyProperty<Boolean>()
   override val apkInstallTimeout = project.emptyProperty<Int>()
+
+  override fun withOrchestrator(value: Any) {
+    withOrchestrator.eval(value)
+  }
 
   override fun shard(value: Any) {
     shard.eval(value)

--- a/plugin/src/main/kotlin/com/trevjonez/composer/ConfiguratorDomainObj.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ConfiguratorDomainObj.kt
@@ -19,7 +19,6 @@ package com.trevjonez.composer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.kotlin.dsl.listProperty
-import org.gradle.kotlin.dsl.property
 
 open class ConfiguratorDomainObj(val name: String, val project: Project) :
     ComposerTaskDsl,
@@ -30,6 +29,7 @@ open class ConfiguratorDomainObj(val name: String, val project: Project) :
   override val outputDir = project.layout.directoryProperty()
 
   override val configuration: Configuration = project.composerConfig()
+  override val withOrchestrator = project.emptyProperty<Boolean>()
   override val shard = project.emptyProperty<Boolean>()
   override val instrumentationArguments =
     project.objects.listProperty<Pair<String, String>>()
@@ -49,6 +49,10 @@ open class ConfiguratorDomainObj(val name: String, val project: Project) :
 
   override fun outputDirectory(path: Any) {
     outputDir.set(project.file(path))
+  }
+
+  override fun withOrchestrator(value: Any) {
+    withOrchestrator.eval(value)
   }
 
   override fun shard(value: Any) {

--- a/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerBasePlugin.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerBasePlugin.kt
@@ -110,6 +110,16 @@ abstract class ComposerBasePlugin<T> : Plugin<Project>
       composerTask: ComposerTask,
       variantConfigurator: ConfiguratorDomainObj?
   ) {
+    if (globalConfig.withOrchestrator.isPresent) {
+      logDslSelection("withOrchestrator", "global")
+      composerTask.withOrchestrator(globalConfig.withOrchestrator)
+    }
+
+    if (variantConfigurator?.withOrchestrator?.isPresent == true) {
+      logDslSelection("withOrchestrator", "variant")
+      composerTask.withOrchestrator(variantConfigurator.withOrchestrator)
+    }
+
     if (globalConfig.shard.isPresent) {
       logDslSelection("shard", "global")
       composerTask.shard(globalConfig.shard)


### PR DESCRIPTION
Since 0.4.0 Composer supports the option --with-orchestrator

On this PR I'm just adding the parameter, in the next PR I should add the task to upload the test service and orchestrator APKs as suggested in: https://github.com/gojuno/composer/pull/157