### PR TITLE
Extra apks ( useful for Orchestrator )

### DIFF
--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerConfig.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerConfig.kt
@@ -24,7 +24,7 @@ import org.gradle.api.artifacts.Configuration
 object ComposerConfig {
     const val MAIN_CLASS = "com.gojuno.composer.MainKt"
     const val COMPOSER = "composer"
-    const val COMPOSER_VER = "0.4.0"
+    const val COMPOSER_VER = "0.5.0"
     const val ARTIFACT_DEP = "com.gojuno.composer:composer:$COMPOSER_VER"
     const val DEFAULT_OUTPUT_DIR = "composer-output"
 }

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerDsl.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerDsl.kt
@@ -16,6 +16,7 @@
 
 package com.trevjonez.composer
 
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 
@@ -127,6 +128,7 @@ interface ComposerTaskDsl : ComposerDsl {
   val testApk: RegularFileProperty
   val apk: RegularFileProperty
   val outputDir: DirectoryProperty
+  val extraApks: ConfigurableFileCollection
 
   /**
    * @param path evaluated as per [org.gradle.api.Project.file].
@@ -142,4 +144,6 @@ interface ComposerTaskDsl : ComposerDsl {
    * @param path evaluated as per [org.gradle.api.Project.file].
    */
   fun outputDirectory(path: Any)
+
+  fun extraApks(paths: Any)
 }

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
@@ -22,6 +22,7 @@ data class ComposerParams(
         val apk: File,
         val testApk: File,
         val withOrchestrator: Boolean?,
+        val orchestratorApks: List<File>,
         val shard: Boolean?,
         val outputDirectory: File?,
         val instrumentationArguments: List<Pair<String, String>>,
@@ -44,7 +45,8 @@ data class ComposerParams(
                 "--test-apk", testApk.absolutePath)
                 .let { params ->
                   withOrchestrator?.takeIf { it }?.let {
-                    params + arrayOf("--with-orchestrator")
+                    val apks = orchestratorApks.map { file -> file.absolutePath }.toTypedArray()
+                    params + arrayOf("--with-orchestrator", "--orchestrator-apks", *apks)
                   } ?: params
                 }
                 .let { params ->

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
@@ -16,13 +16,14 @@
 
 package com.trevjonez.composer
 
+import org.gradle.api.file.FileCollection
 import java.io.File
 
 data class ComposerParams(
         val apk: File,
         val testApk: File,
         val withOrchestrator: Boolean?,
-        val orchestratorApks: List<File>,
+        val extraApks: FileCollection,
         val shard: Boolean?,
         val outputDirectory: File?,
         val instrumentationArguments: List<Pair<String, String>>,
@@ -40,14 +41,19 @@ data class ComposerParams(
     }
 
     fun toCliArgs(): List<String> {
-        return listOf(
+      return listOf(
                 "--apk", apk.absolutePath,
                 "--test-apk", testApk.absolutePath)
                 .let { params ->
                   withOrchestrator?.takeIf { it }?.let {
-                    val apks = orchestratorApks.map { file -> file.absolutePath }.toTypedArray()
-                    params + arrayOf("--with-orchestrator", "--orchestrator-apks", *apks)
+                    params + arrayOf("--with-orchestrator")
                   } ?: params
+                }
+                .let { params ->
+                    extraApks.takeIf { !it.isEmpty }?.let {
+                      val apks = extraApks.map { file -> file.absolutePath }.toTypedArray()
+                      params + arrayOf("--orchestrator-apks", *apks)
+                    } ?: params
                 }
                 .let { params ->
                     shard?.let {

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
@@ -17,9 +17,12 @@
 package com.trevjonez.composer
 
 import com.trevjonez.composer.ComposerConfig.MAIN_CLASS
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.internal.file.TaskFileVarFactory
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
@@ -68,6 +71,9 @@ open class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
   @get:[Optional Input]
   override val apkInstallTimeout = project.emptyProperty<Int>()
 
+  @InputFiles
+  override val extraApks = newInputFiles()
+
   override fun exec() {
     val outputDir = outputDir.get().asFile
 
@@ -77,14 +83,11 @@ open class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
       }
     }
 
-    val apks: List<File> = project.configurations.findByName("androidTestUtil")?.resolvedConfiguration?.files?.toList()
-        ?: emptyList()
-
     val config = ComposerParams(
         apk.asFile.get(),
         testApk.asFile.get(),
         withOrchestrator.orNull,
-        apks,
+        extraApks,
         shard.orNull,
         outputDir,
         instrumentationArguments.orEmpty,
@@ -121,6 +124,10 @@ open class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
 
   override fun testApk(path: Any) {
     testApk.set(project.file(path))
+  }
+
+  override fun extraApks(paths: Any) {
+    extraApks.from(paths)
   }
 
   override fun outputDirectory(path: Any) {
@@ -173,5 +180,9 @@ open class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
 
   override fun apkInstallTimeout(value: Any) {
     apkInstallTimeout.eval(value)
+  }
+
+  internal fun newInputFiles(): ConfigurableFileCollection {
+    return services.get(TaskFileVarFactory::class.java).newInputFileCollection(this)
   }
 }

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
@@ -77,10 +77,14 @@ open class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
       }
     }
 
+    val apks: List<File> = project.configurations.findByName("androidTestUtil")?.resolvedConfiguration?.files?.toList()
+        ?: emptyList()
+
     val config = ComposerParams(
         apk.asFile.get(),
         testApk.asFile.get(),
         withOrchestrator.orNull,
+        apks,
         shard.orNull,
         outputDir,
         instrumentationArguments.orEmpty,

--- a/plugin/src/main/kotlin/com/trevjonez/composer/ConfiguratorDomainObj.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ConfiguratorDomainObj.kt
@@ -27,6 +27,7 @@ open class ConfiguratorDomainObj(val name: String, val project: Project) :
   override val testApk = project.layout.fileProperty()
   override val apk = project.layout.fileProperty()
   override val outputDir = project.layout.directoryProperty()
+  override val extraApks = project.layout.configurableFiles()
 
   override val configuration: Configuration = project.composerConfig()
   override val withOrchestrator = project.emptyProperty<Boolean>()
@@ -49,6 +50,10 @@ open class ConfiguratorDomainObj(val name: String, val project: Project) :
 
   override fun outputDirectory(path: Any) {
     outputDir.set(project.file(path))
+  }
+
+  override fun extraApks(paths: Any) {
+    extraApks.setFrom(paths)
   }
 
   override fun withOrchestrator(value: Any) {

--- a/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerApplicationPlugin.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerApplicationPlugin.kt
@@ -19,12 +19,10 @@ package com.trevjonez.composer.internal
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.api.ApplicationVariant
 import com.trevjonez.composer.ComposerTask
-import com.trevjonez.composer.ConfiguratorDomainObj
 import org.gradle.api.DomainObjectCollection
-import org.gradle.api.file.Directory
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
-import org.gradle.util.Path
 import java.io.File
 
 class ComposerApplicationPlugin : ComposerBasePlugin<ApplicationVariant>() {
@@ -32,6 +30,10 @@ class ComposerApplicationPlugin : ComposerBasePlugin<ApplicationVariant>() {
     requireNotNull(project.extensions.findByName("android") as? AppExtension) {
       "Failed to find android application extension"
     }
+  }
+
+  private val androidTestUtil by lazy(LazyThreadSafetyMode.NONE) {
+    project.configurations.findByName(androidTestUtil)
   }
 
   override val sdkDir: File
@@ -53,4 +55,9 @@ class ComposerApplicationPlugin : ComposerBasePlugin<ApplicationVariant>() {
       testVariant.outputs.single().outputFile
     })
   }
+
+  override val extraApks: ConfigurableFileCollection
+   get() = project.layout.configurableFiles(project.provider{
+     androidTestUtil?.resolvedConfiguration?.files?.toList() ?: emptyList()
+   })
 }

--- a/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerApplicationPlugin.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerApplicationPlugin.kt
@@ -33,7 +33,7 @@ class ComposerApplicationPlugin : ComposerBasePlugin<ApplicationVariant>() {
   }
 
   private val androidTestUtil by lazy(LazyThreadSafetyMode.NONE) {
-    project.configurations.findByName(androidTestUtil)
+    project.configurations.findByName("androidTestUtil")
   }
 
   override val sdkDir: File

--- a/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerBasePlugin.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerBasePlugin.kt
@@ -25,6 +25,7 @@ import com.trevjonez.composer.composerConfig
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
@@ -42,6 +43,8 @@ abstract class ComposerBasePlugin<T> : Plugin<Project>
   open fun T.getOutputDir(task: ComposerTask): Provider<Directory> {
     return project.layout.buildDirectory.dir("reports/composer/$dirName")
   }
+
+  abstract val extraApks: ConfigurableFileCollection
 
   lateinit var project: Project
   lateinit var globalConfig: ConfigExtension
@@ -100,6 +103,11 @@ abstract class ComposerBasePlugin<T> : Plugin<Project>
                                    ?.takeIf { it.isPresent }
                                    ?.also { composerTask.dependsOn(it) }
                                ?: getOutputDir(composerTask))
+
+    composerTask.extraApks.setFrom(variantConfigurator?.extraApks
+        ?.takeUnless{ it.isEmpty }
+        ?.also { composerTask.dependsOn(it) }
+        ?: extraApks)
   }
 
   fun logDslSelection(propertyName: String, source: String) {

--- a/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerLibraryPlugin.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/internal/ComposerLibraryPlugin.kt
@@ -17,11 +17,10 @@
 package com.trevjonez.composer.internal
 
 import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.LibraryVariant
 import com.trevjonez.composer.ComposerTask
 import org.gradle.api.DomainObjectCollection
-import org.gradle.api.file.Directory
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import java.io.File
@@ -31,6 +30,10 @@ class ComposerLibraryPlugin : ComposerBasePlugin<LibraryVariant>() {
     requireNotNull(project.extensions.findByName("android") as? LibraryExtension) {
       "Failed to find android library extension"
     }
+  }
+
+  private val androidTestUtil by lazy(LazyThreadSafetyMode.NONE) {
+    project.configurations.findByName("androidTestUtil")
   }
 
   override val sdkDir: File
@@ -49,4 +52,9 @@ class ComposerLibraryPlugin : ComposerBasePlugin<LibraryVariant>() {
       testVariant.outputs.single().outputFile
     })
   }
+
+  override val extraApks: ConfigurableFileCollection
+    get() = project.layout.configurableFiles(project.provider{
+      androidTestUtil?.resolvedConfiguration?.files?.toList() ?: emptyList()
+    })
 }


### PR DESCRIPTION
depends on #28 
blocked by: https://github.com/gojuno/composer/pull/159

To run tests with Orchestrator two extra APKs are needed: test-services and orchestrator.
Once the PR to composer is hopefully merged the plugin will just provide those APKs to be installed.

Also I'll need to add to the docs that if you want to use Orchestrator with `clearPackageData` enabled you'll need to add: `instrumentationArgument("clearPackageData", "true")` unless we provide a better way ( like reading it directly from the androidExtension ).

What do you thing about it? Maybe I could just name it `androidTestUtilApks` because it's really doing all of them.