### PR TITLE
Update to Composer 0.6.0

### DIFF
--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerConfig.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerConfig.kt
@@ -24,7 +24,7 @@ import org.gradle.api.artifacts.Configuration
 object ComposerConfig {
     const val MAIN_CLASS = "com.gojuno.composer.MainKt"
     const val COMPOSER = "composer"
-    const val COMPOSER_VER = "0.5.0"
+    const val COMPOSER_VER = "0.6.0"
     const val ARTIFACT_DEP = "com.gojuno.composer:composer:$COMPOSER_VER"
     const val DEFAULT_OUTPUT_DIR = "composer-output"
 }

--- a/core/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
+++ b/core/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
@@ -46,7 +46,7 @@ data class ComposerParams(
                 "--test-apk", testApk.absolutePath)
                 .let { params ->
                   withOrchestrator?.takeIf { it }?.let {
-                    params + arrayOf("--with-orchestrator")
+                    params + arrayOf("--with-orchestrator", "true")
                   } ?: params
                 }
                 .let { params ->


### PR DESCRIPTION
Composer supports now the AndroidX test orchestrator with the version **0.6.0**.
This PR updates the version of Composer and adds the boolean `true` to the argument `--with-orchestrator` as required by the latest version.
Composer issue: https://github.com/gojuno/composer/pull/167

Closes: https://github.com/trevjonez/composer-gradle-plugin/issues/35