### PR TITLE
Deal with "--with-orchestrator" arity

### DIFF
--- a/plugin/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ComposerParams.kt
@@ -45,8 +45,8 @@ data class ComposerParams(
                 "--apk", apk.absolutePath,
                 "--test-apk", testApk.absolutePath)
                 .let { params ->
-                  withOrchestrator?.takeIf { it }?.let {
-                    params + arrayOf("--with-orchestrator", "true")
+                  withOrchestrator?.let {
+                    params + arrayOf("--with-orchestrator", "$it")
                   } ?: params
                 }
                 .let { params ->


### PR DESCRIPTION
Make it consistent with params like "shard" or "verboseOutput".