### PR TITLE
Make APK inputs @Classpath to Gradle thread them as a "jar"

### DIFF
--- a/plugin/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
@@ -21,6 +21,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.internal.file.TaskFileVarFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -35,9 +36,11 @@ open class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
 
   override val configuration = project.composerConfig()
 
+  @Classpath
   @InputFile
   override val testApk = project.objects.fileProperty()
 
+  @Classpath
   @InputFile
   override val apk = project.objects.fileProperty().apply { set(testApk) }
 


### PR DESCRIPTION
When the APK is considered a binary file any change in the timestamp of the files inside, or the order, makes it different, but when it's compared as a jar ( zip ) it's not.
Thanks to https://github.com/gradle/gradle/pull/9344 on Gradle 5.6 APKs can be now understood as an archive (zip, jar, aar, apk, ...)

It will mean cacheable UI tests working at ephemeral CI (like Travis) when using the Remote BuildCache