### PR TITLE
Bootstrap Github Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    # Use macOS for emulator hardware acceleration
+    runs-on: macOS-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+ 
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1   
+        
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 1.8
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+
+      - name: Gradle build
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          script: ./gradlew build


### PR DESCRIPTION
Bootstrap `./gradlew build` CI pipeline based on github actions. Relates to https://github.com/trevjonez/composer-gradle-plugin/issues/36

There is no additional registration or configuration seems to be needed. Execution time is also decent. Currently its ~5min including starting android emulator https://github.com/plastiv/composer-gradle-plugin/runs/473061103?check_suite_focus=true

I have mostly ~~copy-pasted~~ inspired from https://github.com/slackhq/keeper/blob/master/.github/workflows/ci.yml

I haven't included gradle dependency or build cache optimization for now. As well as uploading snapshot or publishing tasks. That is something to consider later. 