### PR TITLE
Fix configuration cache compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Items listed here may not be exhaustive, if you are seeing issues, check the git
 - Formatting and some top-level elements have been moved in commander/composer
 - Invoke composer within the project build directory
 - Update to Gradle 6.9, AGP 4.2.1, Kotlin 1.4.32, detekt 1.14.2
+- Fix Configuration Cache compatibility
 
 ## 1.0.0-rc08
 - Support for ANDROID_SDK_ROOT falling back to ANDROID_HOME and warning when appropriate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Items listed here may not be exhaustive, if you are seeing issues, check the git
 ## 1.0.0-rc09
 - Formatting and some top-level elements have been moved in commander/composer
 - Invoke composer within the project build directory
-- Update to Gradle 6.9, AGP 4.2.1, Kotlin 1.4.32, detekt 1.14.2
+- Update to Gradle 7.0, AGP 4.2.1, Kotlin 1.4.32, detekt 1.14.2
 - Fix Configuration Cache compatibility
 
 ## 1.0.0-rc08

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Composer plugin version | Gradle version | Android plugin version
 | 0.13.0     | 5.6                | 3.4.2, 3.5.0-rc01<sup>\*</sup>, 3.6.0-alpha05<sup>\*</sup> |
 | 1.0.0-rc07 | 6.4                | 3.6.2, 4.0.0-beta04<sup>\*</sup>, 4.1.0-alpha05<sup>\*</sup> |
 | 1.0.0-rc08 | 6.6.1              | 4.0.1, 4.1.0-rc01<sup>\*</sup>, 4.2.0-alpha07<sup>\*</sup> |
-| 1.0.0-rc09 | 6.9             | 4.2.1, 7.0.0-beta02<sup>\*</sup>, 7.1.0-alpha01<sup>\*</sup> |
+| 1.0.0-rc09 | 7.0                | 4.2.1, 7.0.0-beta02<sup>\*</sup>, 7.1.0-alpha01<sup>\*</sup> |
 
 \* Alpha, Beta and RC versions of the android plugin are quickly tested by building against them.
 This usually means the published composer plugin will work with those version 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ buildscript {
   }
   dependencies {
     val KOTLIN_VERSION: String by rootProject
-    classpath("org.gradle.kotlin:gradle-kotlin-dsl-plugins:1.4.9")
+    classpath("org.gradle.kotlin:gradle-kotlin-dsl-plugins:2.1.4")
     classpath("com.gradle.publish:plugin-publish-plugin:0.11.0")
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION")
     classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
@@ -85,7 +85,7 @@ abstract class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl 
     val buildDirectory = project.layout.buildDirectory
     outputDir.convention(buildDirectory.dir(ComposerConfig.DEFAULT_OUTPUT_DIR))
     workDir.convention(buildDirectory.dir(ComposerConfig.DEFAULT_WORK_DIR))
-    setWorkingDir(workDir.map { it.also { it.asFile.mkdirs() } })
+    setWorkingDir(workDir)
     mainClass.set(MAIN_CLASS)
     classpath = project.composerConfig()
   }

--- a/plugin/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/composer/ComposerTask.kt
@@ -19,7 +19,6 @@
 package com.trevjonez.composer
 
 import com.trevjonez.composer.ComposerConfig.MAIN_CLASS
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -37,8 +36,6 @@ import java.io.File
 
 @CacheableTask
 abstract class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl {
-
-  private val configuration: Configuration = project.composerConfig()
 
   @get:[Classpath InputFile]
   abstract override val testApk: RegularFileProperty
@@ -90,7 +87,7 @@ abstract class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl 
     workDir.convention(buildDirectory.dir(ComposerConfig.DEFAULT_WORK_DIR))
     setWorkingDir(workDir.map { it.also { it.asFile.mkdirs() } })
     mainClass.set(MAIN_CLASS)
-    classpath = configuration
+    classpath = project.composerConfig()
   }
 
   override fun exec() {
@@ -111,14 +108,14 @@ abstract class ComposerTask : JavaExec(), ComposerConfigurator, ComposerTaskDsl 
         shard.orNull,
         outputDir,
         instrumentationArguments.getOrElse(emptyList()),
-        verboseOutput.orNull ?: project.hasProperty("composerVerbose"),
+        verboseOutput.orNull ?: providerFactory.gradleProperty("composerVerbose").isPresent,
         devices.getOrElse(emptyList()),
         devicePattern.orNull,
         keepOutput.orNull,
         apkInstallTimeout.orNull)
 
     args = config.toCliArgs().also {
-      project.logger.info(
+      logger.info(
           it.joinToString(prefix = "ComposerTask: args: =`", postfix = "`")
       )
     }

--- a/plugin/src/test/kotlin/com/trevjonez/composer/ComposerPluginTest.kt
+++ b/plugin/src/test/kotlin/com/trevjonez/composer/ComposerPluginTest.kt
@@ -213,6 +213,26 @@ class ComposerPluginTest {
         "--install-timeout, 10")
   }
 
+  /**
+   * Run with at least one device/emulator connected
+   */
+  @Test
+  fun `reuse configuration cache`() {
+    val projectDir = testProjectDir.newFolder("basicTest").apply {
+      andTest.copyRecursively(this, true)
+      writeLocalProps()
+    }
+
+
+    gradleRunner(projectDir, "--configuration-cache", "testDebugComposer")
+            .buildAndFail()
+
+    val result = gradleRunner(projectDir, "--configuration-cache", "testDebugComposer")
+            .buildAndFail()
+
+    assertThat(result.output).contains("Reusing configuration cache.")
+  }
+
   private val environmentVariable: ReadOnlyProperty<Any, String>
     get() {
       return object : ReadOnlyProperty<Any, String> {


### PR DESCRIPTION
Fixes #82 

Test is taken from https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:testing

Gradle 7 update is not required as replacement apis are available in previous gradle version. I've bumped them together since I wanted to additionally to CI verify fork with working project which is already on gradle 7. Before plugin is published on mavencentral it is possible to check with local  dependency substitution.  

```
// settings.gradle
includeBuild("/Users/plastiv/Projects/composer-gradle-plugin") {
    dependencySubstitution {
        substitute(module("com.trevjonez.composer:plugin")).with(project(":plugin"))
    }
}
```